### PR TITLE
fix: breaking math

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,4 +85,4 @@ function SquircleBackground({
 }
 
 export { SquircleView }
-export type { SquircleParams, SquircleViewProps }
+export type { SquircleParams }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -62,8 +62,8 @@ function SquircleBackground({
           d={
             squircleSize
               ? getSvgPath({
-                  width: squircleSize.width - strokeWidth,
-                  height: squircleSize.height - strokeWidth,
+                  width: Math.max(squircleSize.width - strokeWidth, 0),
+                  height: Math.max(squircleSize.height - strokeWidth, 0),
                   cornerSmoothing,
                   cornerRadius,
                   topLeftCornerRadius,
@@ -85,4 +85,4 @@ function SquircleBackground({
 }
 
 export { SquircleView }
-export type { SquircleParams }
+export type { SquircleParams, SquircleViewProps }


### PR DESCRIPTION
`width | height` should not be `NaN` or negative. This can happen with `onLayout` first init.