### PR TITLE
Fix stroke not being drawn properly

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,8 +48,8 @@ function SquircleBackground({
     <Rect style={StyleSheet.absoluteFill}>
       {({ width, height }) => {
         const squirclePath = getSvgPath({
-          width: width,
-          height: height,
+          width,
+          height,
           cornerSmoothing,
           cornerRadius,
           topLeftCornerRadius,
@@ -58,7 +58,15 @@ function SquircleBackground({
           bottomLeftCornerRadius,
         })
 
-        if (strokeWidth > 0) {
+        const hasStroke = strokeWidth > 0
+
+        if (!hasStroke) {
+          return (
+            <Svg>
+              <Path d={squirclePath} fill={fillColor} />
+            </Svg>
+          )
+        } else {
           // Since SVG doesn't support inner stroke, we double the stroke width
           // and remove the outer half with clipPath
           return (
@@ -75,12 +83,6 @@ function SquircleBackground({
                 stroke={strokeColor}
                 strokeWidth={strokeWidth * 2}
               />
-            </Svg>
-          )
-        } else {
-          return (
-            <Svg>
-              <Path d={squirclePath} fill={fillColor} />
             </Svg>
           )
         }


### PR DESCRIPTION
SVG only supports center stroke, but we want the stroke to stay inside the shape. At the moment, we work around this by drawing a slightly smaller path so that the stroke can fit inside. This solution, however, has some issues:

- As addressed in https://github.com/tienphaw/react-native-figma-squircle/pull/9, width/height could negative.
- We're using the same radius to draw the inner path, which means when the stroke is applied, the outer radius will appear larger.

## Changes in this PR
- Add a `Rect` component that helps provide the width/height of the `SquircleView`.
- Double the stroke width remove the outer part with a `ClipPath`, this also removes the need to recalculate a new width/height/radius.