### PR TITLE
Replaced `@react/auto-id` with `nanoid`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-figma-squircle",
   "description": "Figma-flavored squircles for React Native",
   "author": "Tien Pham",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "license": "MIT",
   "main": "lib/commonjs/index.js",
   "react-native": "src/index.tsx",
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "figma-squircle": "^0.2.1",
-    "nanoid": "^4.0.2"
+    "nanoid": "^4.0.2",
+    "react-native-get-random-values": "^1.9.0"
   },
   "devDependencies": {
     "@types/react": "~16.9.35",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-figma-squircle",
   "description": "Figma-flavored squircles for React Native",
   "author": "Tien Pham",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "main": "lib/commonjs/index.js",
   "react-native": "src/index.tsx",
@@ -20,8 +20,8 @@
     "react-native-svg": "*"
   },
   "dependencies": {
-    "@reach/auto-id": "^0.17.0",
-    "figma-squircle": "^0.2.1"
+    "figma-squircle": "^0.2.1",
+    "nanoid": "^4.0.2"
   },
   "devDependencies": {
     "@types/react": "~16.9.35",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { ViewProps, View, StyleSheet } from 'react-native'
 import { PropsWithChildren, ReactNode, useState } from 'react'
 import Svg, { ClipPath, Color, Defs, Path } from 'react-native-svg'
 import { getSvgPath } from 'figma-squircle'
+import 'react-native-get-random-values'
 import { nanoid } from 'nanoid'
 
 interface SquircleParams {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,7 +46,7 @@ function SquircleBackground({
   strokeColor = '#000',
   strokeWidth = 0,
 }: SquircleParams) {
-  const squircleId = nanoid()
+  const [clipPathId] = React.useState(() => `clip-${nanoid()}`)
 
   return (
     <Rect style={StyleSheet.absoluteFill}>
@@ -73,8 +73,6 @@ function SquircleBackground({
         } else {
           // Since SVG doesn't support inner stroke, we double the stroke width
           // and remove the outer half with clipPath
-          const clipPathId = `clip-${squircleId}`
-
           return (
             <Svg width="100%" height="100%" viewBox={`0 0 ${width} ${height}`}>
               <Defs>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { ViewProps, View, StyleSheet } from 'react-native'
 import { PropsWithChildren, ReactNode, useState } from 'react'
 import Svg, { ClipPath, Color, Defs, Path } from 'react-native-svg'
 import { getSvgPath } from 'figma-squircle'
-import { useId } from "@reach/auto-id";
+import { nanoid } from 'nanoid'
 
 interface SquircleParams {
   cornerRadius?: number
@@ -45,7 +45,7 @@ function SquircleBackground({
   strokeColor = '#000',
   strokeWidth = 0,
 }: SquircleParams) {
-  const squircleId = useId()
+  const squircleId = nanoid()
 
   return (
     <Rect style={StyleSheet.absoluteFill}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1180,22 +1180,6 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@reach/auto-id@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.17.0.tgz#60cce65eb7a0d6de605820727f00dfe2b03b5f17"
-  integrity sha512-ud8iPwF52RVzEmkHq1twuqGuPA+moreumUHdtgvU3sr3/15BNhwp3KyDLrKKSz0LP1r3V4pSdyF9MbYM8BoSjA==
-  dependencies:
-    "@reach/utils" "0.17.0"
-    tslib "^2.3.0"
-
-"@reach/utils@0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.17.0.tgz#3d1d2ec56d857f04fe092710d8faee2b2b121303"
-  integrity sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==
-  dependencies:
-    tiny-warning "^1.0.3"
-    tslib "^2.3.0"
-
 "@react-native-community/cli-debugger-ui@^4.13.1":
   version "4.13.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-4.13.1.tgz#07de6d4dab80ec49231de1f1fbf658b4ad39b32c"
@@ -4653,6 +4637,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
+nanoid@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.2.tgz#140b3c5003959adbebf521c170f282c5e7f9fb9e"
+  integrity sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -6123,11 +6112,6 @@ time-stamp@^1.0.0:
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
   integrity sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=
 
-tiny-warning@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
-  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -6196,11 +6180,6 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.3.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.17.1:
   version "3.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3041,6 +3041,11 @@ fancy-log@^1.3.2:
     parse-node-version "^1.0.0"
     time-stamp "^1.0.0"
 
+fast-base64-decode@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fast-base64-decode/-/fast-base64-decode-1.0.0.tgz#b434a0dd7d92b12b43f26819300d2dafb83ee418"
+  integrity sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -5271,6 +5276,13 @@ react-native-builder-bob@^0.18.1:
     yargs "^16.2.0"
   optionalDependencies:
     jetifier "^1.6.6"
+
+react-native-get-random-values@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/react-native-get-random-values/-/react-native-get-random-values-1.9.0.tgz#6cb30511c406922e75fe73833dc1812a85bfb37e"
+  integrity sha512-+29IR2oxzxNVeaRwCqGZ9ABadzMI8SLTBidrIDXPOkKnm5+kEmLt34QKM4JV+d2usPErvKyS85le0OmGTHnyWQ==
+  dependencies:
+    fast-base64-decode "^1.0.0"
 
 react-native-svg@12.1.0:
   version "12.1.0"


### PR DESCRIPTION
`@react/auto-id` doesn't support React versions higher than 17.
Replacing it with `nanoid` give us the same functionality with a lighter and faster package.