### PR TITLE
Add gradient colour support to SquircleView's stroke and fill props.

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -70,7 +70,18 @@ function SquircleBackground({
         if (!hasStroke) {
           return (
             <Svg width="100%" height="100%" viewBox={`0 0 ${width} ${height}`}>
-              <Path d={squirclePath} fill={fillColor} />
+              {
+                fillGradientColors?.length ?
+                  <Defs>
+                    <LinearGradient id="fillGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+                      {fillGradientColors?.map((color, index) => (
+                        <Stop key={index} offset={`${(index / (fillGradientColors.length - 1)) * 100}%`} stopColor={color} />
+                      ))}
+                    </LinearGradient>
+                  </Defs>
+                  : null
+              }
+              <Path d={squirclePath} fill={fillGradientColors?.length ? "url(#fillGradient)" : fillColor} />
             </Svg>
           )
         } else {
@@ -78,6 +89,7 @@ function SquircleBackground({
           // and remove the outer half with clipPath
           const clipPathId = `clip-${squircleId}`
 
+          // @ts-ignore
           return (
             <Svg width="100%" height="100%" viewBox={`0 0 ${width} ${height}`}>
               <Defs>


### PR DESCRIPTION
This commit introduces a significant enhancement to the `SquircleView` component by adding support for gradient colors in both stroke and fill properties. The `SquircleView` component now empowers developers to seamlessly apply gradients to the strokes and fills of squircle shapes, thereby elevating the visual sophistication of UI elements.

The newly added feature enables the utilisation of gradient arrays for both stroke and fill properties. Developers can provide an array of colours, and the `SquircleView` component will create gradients that smoothly transition between the specified colours. This feature enhances design flexibility, making it easier to achieve gradient effects for both outlines and interior regions of squircles.

To achieve this, the code leverages the principles demonstrated earlier. For each gradient, a `<Defs>` element is used to define the gradient's configuration. Inside this element, a `<LinearGradient>` is constructed with `<Stop>` elements based on the colour array.

New props:
-   fillGradientColors?: Color[]
-   strokeGradientColors?: Color[]